### PR TITLE
feat: re-add django pin to config

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.9]
+        python-version: [3.9, 3.11]
 
     steps:
     - uses: actions/checkout@v3

--- a/setup.cfg
+++ b/setup.cfg
@@ -25,8 +25,8 @@ include_package_data = True
 packages = find:
 python_requires = >=3.9
 install_requires =
-    Django >= 3.0
-    slack-sdk==3.11.2
+    Django >= 3.0, <4
+    slack-sdk==3.19.2
     # FIXME: make locks an optional dependency (and use, in the run_bot command)
     django-database-locks < 1
     django-logbasecommand < 1

--- a/tox.ini
+++ b/tox.ini
@@ -15,7 +15,6 @@ setenv =
 allowlist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
-allowlist_externals = make
 
 [testenv:flake8]
 basepython = python3

--- a/tox.ini
+++ b/tox.ini
@@ -12,7 +12,7 @@ deps =
 setenv =
     PYTHONPATH = {toxinidir}
     DJANGO_SETTINGS_MODULE = testapp.settings
-whitelist_externals = make
+allowlist_externals = make
 pip_pre = True
 commands = make coverage TEST_ARGS='{posargs:tests}'
 allowlist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -1,12 +1,11 @@
 [tox]
 envlist =
     flake8
-    py{39}-dj{32,41}
+    py{39}-dj{32}
 
 [testenv]
 deps =
     dj32: Django==3.2.*
-    dj41: Django==4.1.*
     coverage
     pytest
 setenv =

--- a/tox.ini
+++ b/tox.ini
@@ -1,8 +1,7 @@
 [tox]
 envlist =
     flake8
-    py{39}-dj{32}
-    py{311}-dj{32}
+    py{39,311}-dj{22,30,32}
 
 [testenv]
 deps =

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     flake8
     py{39}-dj{32}
+    py{311}-dj{32}
 
 [testenv]
 deps =


### PR DESCRIPTION
As discussed in other apps, we do not have sufficient test coverage (integraton tests, that is) to ensure migrating to a major version would not cause backwards incompatibilities.

Closes #14 