### PR TITLE
Process messages env

### DIFF
--- a/slackbot/base.py
+++ b/slackbot/base.py
@@ -9,6 +9,7 @@ class MessageProcessor:
     PROCESSED = 2
 
     handle_bot_messages = False
+    handle_messages = True
 
     def __init__(self, rtm_client, web_client) -> None:
         self.client = rtm_client
@@ -36,7 +37,7 @@ class MessageProcessor:
 
         any other value will be ignored
         """
-        if not self.handle_bot_messages and "bot_id" in kw.get("raw", {}):
+        if (not self.handle_bot_messages and "bot_id" in kw.get("raw", {})) or not self.handle_messages:
             return
         return self.handle(message, **kw)
 


### PR DESCRIPTION
Add `handle_messages` variable

We would like to be able to dynamically stop the bot from processing messages in one env (dev for example) because the token is used in multiple places.

Having this can help us ensure the messages are only processed ( or not processed) in a specific place is multiple instances of the same bot are running in different places.