### PR TITLE
 Make sure the bot does not respond to words containing the command 

### DIFF
--- a/slackbot/base.py
+++ b/slackbot/base.py
@@ -82,7 +82,8 @@ class SlackArgumentParser(argparse.ArgumentParser):
         prog = self.prog.lower()
 
         if isinstance(args, str):
-            if not args.lower().startswith(prog):
+            prog_from_message = args.split(" ")[0]
+            if prog_from_message != prog:
                 raise NoMatchSlackCommand
             args = shlex.split(args)
         elif args[0].lower() != prog:

--- a/testapp/testapp/urls.py
+++ b/testapp/testapp/urls.py
@@ -13,9 +13,10 @@ Including another URLconf
     1. Import the include() function: from django.urls import include, path
     2. Add a URL to urlpatterns:  path('blog/', include('blog.urls'))
 """
+
 from django.contrib import admin
 from django.urls import path
 
 urlpatterns = [
-    path('admin/', admin.site.urls),
+    path("admin/", admin.site.urls),
 ]

--- a/testapp/tests/test_arg_parser.py
+++ b/testapp/tests/test_arg_parser.py
@@ -24,6 +24,9 @@ class Test(TestCase):
         with pytest.raises(NoMatchSlackCommand):
             parser.parse_args("someothercmd bla bla")
 
+        with pytest.raises(NoMatchSlackCommand):
+            parser.parse_args("cmdnot bla bla")
+
         with pytest.raises(ExitSlackCommand, match=".*the following arguments are required: str.*"):
             parser.parse_args("cmd")
 


### PR DESCRIPTION
Currently the bot will respond if a message will start with a word containing the command.

Make sure the command is the whole word in the check to not have false positives.

![image](https://github.com/surface-security/django-slack-processor/assets/91122533/d63fc867-11fe-4033-80dd-5eb6f0603eda)
